### PR TITLE
Ensure Windows event loop policy for contact service

### DIFF
--- a/contact-management-service/main.py
+++ b/contact-management-service/main.py
@@ -16,6 +16,9 @@ from dotenv import load_dotenv
 load_dotenv()
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@localhost:5432/campaign_db")
 
+if os.name == "nt":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
 # Structured logging & metrics
 tuple_processors = [
     structlog.processors.TimeStamper(fmt="iso"),


### PR DESCRIPTION
## Summary
- set WindowsSelectorEventLoopPolicy on Windows before creating AsyncConnectionPool

## Testing
- `pytest`
- `uvicorn contact-management-service.main:app --port 8000` *(fails: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6893b106a9d8832d85456e9500e62dc0