### PR TITLE
Fix Windows event loop for contact management

### DIFF
--- a/contact-management-service/run.py
+++ b/contact-management-service/run.py
@@ -1,0 +1,8 @@
+import os
+import asyncio
+import uvicorn
+
+if __name__ == "__main__":
+    if os.name == "nt":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    uvicorn.run("main:app", host="0.0.0.0", port=8002)


### PR DESCRIPTION
## Summary
- add a small runner that sets `WindowsSelectorEventLoopPolicy` before starting Uvicorn

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894c445ead8832da31f3cc1371f1c23