### PR TITLE
Propagate IndiaMART lead fields and show in UI

### DIFF
--- a/campaign-management-service/frontend/ui/package-lock.json
+++ b/campaign-management-service/frontend/ui/package-lock.json
@@ -25,6 +25,8 @@
       },
       "devDependencies": {
         "@emotion/babel-plugin": "^11.10.0",
+        "@testing-library/jest-dom": "^6.6.4",
+        "@testing-library/react": "^16.3.0",
         "css-loader": "^6.8.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "mini-css-extract-plugin": "^2.7.6",
@@ -34,6 +36,13 @@
         "react-scripts": "^5.0.1",
         "style-loader": "^3.3.3"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz",
+      "integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -4759,6 +4768,95 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.4.tgz",
+      "integrity": "sha512-xDXgLjVunjHqczScfkCJ9iyjdNOVHvvCdqHSSxwM9L0l/wHkTRum67SDc020uAlCoqktJplgO2AAQeLP1wgqDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -4778,6 +4876,14 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7635,6 +7741,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssdb": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.3.1.tgz",
@@ -8013,6 +8126,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -8138,6 +8262,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -10900,6 +11031,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -13046,6 +13187,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -13224,6 +13376,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-css-extract-plugin": {
@@ -17190,6 +17352,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -18759,6 +18935,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -19661,9 +19850,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -19672,7 +19861,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/campaign-management-service/frontend/ui/package.json
+++ b/campaign-management-service/frontend/ui/package.json
@@ -20,6 +20,8 @@
   },
   "devDependencies": {
     "@emotion/babel-plugin": "^11.10.0",
+    "@testing-library/jest-dom": "^6.6.4",
+    "@testing-library/react": "^16.3.0",
     "css-loader": "^6.8.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "mini-css-extract-plugin": "^2.7.6",

--- a/campaign-management-service/frontend/ui/src/components/CampaignManager.jsx
+++ b/campaign-management-service/frontend/ui/src/components/CampaignManager.jsx
@@ -34,6 +34,7 @@ const toWsURL = (httpUrl, path) => {
 const PERSONALIZATION_TOKENS = [
   '{{ contact.name }}',
   '{{ contact.email }}',
+  '{{ contact.phone }}',
   '{{ contact.city }}',
   '{{ contact.state }}',
   '{{ contact.company }}',
@@ -160,7 +161,13 @@ const CampaignManager = React.memo(function CampaignManager() {
     if (query.trim()) {
       const q = query.toLowerCase();
       list = list.filter(c =>
-        (c.name?.toLowerCase().includes(q)) || (c.email?.toLowerCase().includes(q))
+        (c.name?.toLowerCase().includes(q)) ||
+        (c.email?.toLowerCase().includes(q)) ||
+        (c.phone_number?.toLowerCase().includes(q)) ||
+        (c.company_name?.toLowerCase().includes(q)) ||
+        (c.city?.toLowerCase().includes(q)) ||
+        (c.state?.toLowerCase().includes(q)) ||
+        (c.unique_query_id?.toLowerCase().includes(q))
       );
     }
     return list;
@@ -290,9 +297,10 @@ const CampaignManager = React.memo(function CampaignManager() {
     return tpl
       .replaceAll('{{ contact.name }}', contact.name ?? '')
       .replaceAll('{{ contact.email }}', contact.email ?? '')
+      .replaceAll('{{ contact.phone }}', contact.phone ?? contact.phone_number ?? '')
       .replaceAll('{{ contact.city }}', contact.city ?? '')
       .replaceAll('{{ contact.state }}', contact.state ?? '')
-      .replaceAll('{{ contact.company }}', contact.company ?? '');
+      .replaceAll('{{ contact.company }}', contact.company ?? contact.company_name ?? '');
   }, []);
 
   // Unsubscribe helper
@@ -473,6 +481,11 @@ const CampaignManager = React.memo(function CampaignManager() {
               </TableCell>
               <TableCell>Loading...</TableCell>
               <TableCell>Loading...</TableCell>
+              <TableCell>Loading...</TableCell>
+              <TableCell>Loading...</TableCell>
+              <TableCell>Loading...</TableCell>
+              <TableCell>Loading...</TableCell>
+              <TableCell>Loading...</TableCell>
               <TableCell>
                 <Button disabled>Loading...</Button>
               </TableCell>
@@ -480,7 +493,7 @@ const CampaignManager = React.memo(function CampaignManager() {
           ))}
           {!loading && listForTable && listForTable.length === 0 && (
             <TableRow>
-              <TableCell colSpan={4} sx={{ color: '#ff8585', textAlign: 'center' }}>
+              <TableCell colSpan={9} sx={{ color: '#ff8585', textAlign: 'center' }}>
                 No contacts available. Please ingest or retry.
               </TableCell>
             </TableRow>
@@ -505,6 +518,11 @@ const CampaignManager = React.memo(function CampaignManager() {
           </TableCell>
           <TableCell sx={{ color: '#fff' }}>{row.name}</TableCell>
           <TableCell sx={{ color: '#fff' }}>{row.email}</TableCell>
+          <TableCell sx={{ color: '#fff' }}>{row.phone_number}</TableCell>
+          <TableCell sx={{ color: '#fff' }}>{row.company_name}</TableCell>
+          <TableCell sx={{ color: '#fff' }}>{row.city}</TableCell>
+          <TableCell sx={{ color: '#fff' }}>{row.state}</TableCell>
+          <TableCell sx={{ color: '#fff' }}>{row.unique_query_id}</TableCell>
           <TableCell>
             <Box display="flex" gap={1}>
               <Button
@@ -572,7 +590,7 @@ const CampaignManager = React.memo(function CampaignManager() {
                 <TextField
                   inputRef={searchRef}
                   size="small"
-                  placeholder="Search name or email…"
+                  placeholder="Search name, email, phone, company, city, state, or ID…"
                   onChange={(e) => setQuery(e.target.value)}
                   inputProps={{ 'aria-label': 'Search contacts' }}
                   sx={{ minWidth: 240 }}
@@ -636,6 +654,21 @@ const CampaignManager = React.memo(function CampaignManager() {
                       Email
                     </TableCell>
                     <TableCell sx={{ bgcolor: 'rgba(255,255,255,0.06)', color: '#c3d7ff', fontWeight: 700 }}>
+                      Phone
+                    </TableCell>
+                    <TableCell sx={{ bgcolor: 'rgba(255,255,255,0.06)', color: '#c3d7ff', fontWeight: 700 }}>
+                      Company
+                    </TableCell>
+                    <TableCell sx={{ bgcolor: 'rgba(255,255,255,0.06)', color: '#c3d7ff', fontWeight: 700 }}>
+                      City
+                    </TableCell>
+                    <TableCell sx={{ bgcolor: 'rgba(255,255,255,0.06)', color: '#c3d7ff', fontWeight: 700 }}>
+                      State
+                    </TableCell>
+                    <TableCell sx={{ bgcolor: 'rgba(255,255,255,0.06)', color: '#c3d7ff', fontWeight: 700 }}>
+                      Unique ID
+                    </TableCell>
+                    <TableCell sx={{ bgcolor: 'rgba(255,255,255,0.06)', color: '#c3d7ff', fontWeight: 700 }}>
                       Actions
                     </TableCell>
                   </TableRow>
@@ -669,7 +702,7 @@ const CampaignManager = React.memo(function CampaignManager() {
 
             {/* Token palette */}
             <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
-              {['{{ contact.name }}','{{ contact.email }}','{{ contact.company }}','{{ contact.city }}','{{ contact.state }}','{{ unsubscribe }}'].map(tok => (
+              {['{{ contact.name }}','{{ contact.email }}','{{ contact.phone }}','{{ contact.company }}','{{ contact.city }}','{{ contact.state }}','{{ unsubscribe }}'].map(tok => (
                 <Button
                   key={tok}
                   size="small"

--- a/campaign-management-service/frontend/ui/yarn.lock
+++ b/campaign-management-service/frontend/ui/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adobe/css-tools@^4.4.0":
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz"
+  integrity sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==
+
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
   resolved "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz"
@@ -2276,6 +2281,40 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@testing-library/dom@^10.0.0":
+  version "10.4.1"
+  resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz"
+  integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.3.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    picocolors "1.1.1"
+    pretty-format "^27.0.2"
+
+"@testing-library/jest-dom@^6.6.4":
+  version "6.6.4"
+  resolved "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.4.tgz"
+  integrity sha512-xDXgLjVunjHqczScfkCJ9iyjdNOVHvvCdqHSSxwM9L0l/wHkTRum67SDc020uAlCoqktJplgO2AAQeLP1wgqDQ==
+  dependencies:
+    "@adobe/css-tools" "^4.4.0"
+    aria-query "^5.0.0"
+    css.escape "^1.5.1"
+    dom-accessibility-api "^0.6.3"
+    lodash "^4.17.21"
+    picocolors "^1.1.1"
+    redent "^3.0.0"
+
+"@testing-library/react@^16.3.0":
+  version "16.3.0"
+  resolved "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz"
+  integrity sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"
@@ -2285,6 +2324,11 @@
   version "0.2.0"
   resolved "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14", "@types/babel__core@^7.1.9":
   version "7.20.5"
@@ -2520,7 +2564,7 @@
   resolved "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz"
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
 
-"@types/react@*", "@types/react@^17.0.0 || ^18.0.0 || ^19.0.0":
+"@types/react@*", "@types/react@^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react@^18.0.0 || ^19.0.0":
   version "19.1.9"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz"
   integrity sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==
@@ -3044,10 +3088,17 @@ argparse@^2.0.1:
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aria-query@^5.3.2:
+aria-query@^5.0.0, aria-query@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
+
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
 
 array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
   version "1.0.2"
@@ -4016,6 +4067,11 @@ css-what@^6.0.1:
   resolved "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz"
   integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz"
+  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
+
 cssdb@^7.1.0:
   version "7.11.2"
   resolved "https://registry.npmjs.org/cssdb/-/cssdb-7.11.2.tgz"
@@ -4243,6 +4299,11 @@ depd@2.0.0:
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
@@ -4308,6 +4369,16 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
+dom-accessibility-api@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz"
+  integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -5785,6 +5856,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
@@ -6980,6 +7056,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.9"
   resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz"
@@ -7084,6 +7165,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 mini-css-extract-plugin@^2.4.5, mini-css-extract-plugin@^2.7.6:
   version "2.9.2"
@@ -7563,7 +7649,7 @@ picocolors@^0.2.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz"
   integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
 
-picocolors@^1.0.0, picocolors@^1.1.1:
+picocolors@^1.0.0, picocolors@^1.1.1, picocolors@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -8429,7 +8515,7 @@ pretty-error@^4.0.0:
     lodash "^4.17.20"
     renderkid "^3.0.0"
 
-pretty-format@^27.5.1:
+pretty-format@^27.0.2, pretty-format@^27.5.1:
   version "27.5.1"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz"
   integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
@@ -8595,7 +8681,7 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-"react-dom@^17.0.0 || ^18.0.0 || ^19.0.0", react-dom@^18.0.0, react-dom@^18.2.0, react-dom@>=16, react-dom@>=16.6.0, react-dom@>=16.8:
+"react-dom@^17.0.0 || ^18.0.0 || ^19.0.0", react-dom@^18.0.0, "react-dom@^18.0.0 || ^19.0.0", react-dom@^18.2.0, react-dom@>=16, react-dom@>=16.6.0, react-dom@>=16.8:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
   integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
@@ -8725,7 +8811,7 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@*, "react@^17.0.0 || ^18.0.0 || ^19.0.0", react@^18.0.0, react@^18.2.0, react@^18.3.1, "react@>= 16", react@>=16, react@>=16.6.0, react@>=16.8, react@>=16.8.0:
+react@*, "react@^17.0.0 || ^18.0.0 || ^19.0.0", react@^18.0.0, "react@^18.0.0 || ^19.0.0", react@^18.2.0, react@^18.3.1, "react@>= 16", react@>=16, react@>=16.6.0, react@>=16.8, react@>=16.8.0:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react/-/react-18.3.1.tgz"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
@@ -8774,6 +8860,14 @@ recursive-readdir@^2.2.2:
   integrity sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==
   dependencies:
     minimatch "^3.0.5"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
@@ -9607,6 +9701,13 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
+
 strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
@@ -10012,9 +10113,9 @@ typedarray-to-buffer@^3.1.5:
     is-typedarray "^1.0.0"
 
 "typescript@^3.2.1 || ^4", "typescript@>= 2.7", "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta", typescript@>=4.9.5:
-  version "5.9.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz"
-  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
+  version "4.9.5"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"

--- a/contact-management-service/main.py
+++ b/contact-management-service/main.py
@@ -119,6 +119,9 @@ class ContactCreate(BaseModel):
     email: EmailStr
     phone_number: Optional[str] = None
     company_name: Optional[str] = None
+    unique_query_id: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
 
     @field_validator("name")
     def validate_name(cls, v: str) -> str:
@@ -131,6 +134,9 @@ class ContactUpdate(BaseModel):
     email: Optional[EmailStr] = None
     phone_number: Optional[str] = None
     company_name: Optional[str] = None
+    unique_query_id: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
     dnc: Optional[bool] = None
 
     @field_validator("name")
@@ -145,6 +151,9 @@ class Contact(BaseModel):
     email: EmailStr
     phone_number: Optional[str]
     company_name: Optional[str]
+    unique_query_id: Optional[str]
+    city: Optional[str]
+    state: Optional[str]
     dnc: bool
     created_at: datetime
     updated_at: datetime
@@ -224,9 +233,17 @@ async def create_contact(contact: ContactCreate, request: Request):
             async with conn.cursor(row_factory=dict_row) as cur:
                 try:
                     await cur.execute(
-                        "INSERT INTO contacts (name,email,phone_number,company_name) "
-                        "VALUES (%s,%s,%s,%s) RETURNING *",
-                        (contact.name, contact.email, contact.phone_number, contact.company_name),
+                        "INSERT INTO contacts (name,email,phone_number,company_name,unique_query_id,city,state) "
+                        "VALUES (%s,%s,%s,%s,%s,%s,%s) RETURNING *",
+                        (
+                            contact.name,
+                            contact.email,
+                            contact.phone_number,
+                            contact.company_name,
+                            contact.unique_query_id,
+                            contact.city,
+                            contact.state,
+                        ),
                     )
                     new = await cur.fetchone()
                     await broadcast(request.app, "contacts_added", {"created_count": 1})
@@ -350,9 +367,17 @@ async def batch_create_contacts(contacts: List[ContactCreate], request: Request)
                 for c in contacts:
                     try:
                         await cur.execute(
-                            "INSERT INTO contacts (name,email,phone_number,company_name) "
-                            "VALUES (%s,%s,%s,%s)",
-                            (c.name, c.email, c.phone_number, c.company_name),
+                            "INSERT INTO contacts (name,email,phone_number,company_name,unique_query_id,city,state) "
+                            "VALUES (%s,%s,%s,%s,%s,%s,%s)",
+                            (
+                                c.name,
+                                c.email,
+                                c.phone_number,
+                                c.company_name,
+                                c.unique_query_id,
+                                c.city,
+                                c.state,
+                            ),
                         )
                         success += 1
                     except Exception as e:

--- a/contact-management-service/migrations/002_add_indiamart_fields.sql
+++ b/contact-management-service/migrations/002_add_indiamart_fields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE contacts
+    ADD COLUMN IF NOT EXISTS unique_query_id TEXT,
+    ADD COLUMN IF NOT EXISTS city TEXT,
+    ADD COLUMN IF NOT EXISTS state TEXT;

--- a/lead-processing-service/api.py
+++ b/lead-processing-service/api.py
@@ -27,6 +27,9 @@ class LeadIn(BaseModel):
     SENDER_NAME: Optional[str] = ""
     SENDER_MOBILE: Optional[str] = ""
     SENDER_COMPANY: Optional[str] = ""
+    UNIQUE_QUERY_ID: Optional[str] = ""
+    CITY: Optional[str] = ""
+    STATE: Optional[str] = ""
 
 # --- rabbit helper
 def _get_channel():
@@ -98,6 +101,9 @@ async def upload_csv(file: UploadFile = File(...)):
         name  = (row.get("name") or "").strip()
         phone = (row.get("phone") or "").strip()
         comp  = (row.get("company") or "").strip()
+        uqid  = (row.get("unique_query_id") or row.get("UNIQUE_QUERY_ID") or "").strip()
+        city  = (row.get("city") or row.get("CITY") or "").strip()
+        state = (row.get("state") or row.get("STATE") or "").strip()
 
         if not email:
             errors.append({"line": line_no, "error": "Missing email"})
@@ -107,7 +113,10 @@ async def upload_csv(file: UploadFile = File(...)):
             "SENDER_EMAIL":   email,
             "SENDER_NAME":    name,
             "SENDER_MOBILE":  phone,
-            "SENDER_COMPANY": comp
+            "SENDER_COMPANY": comp,
+            "UNIQUE_QUERY_ID": uqid,
+            "CITY":           city,
+            "STATE":          state,
         })
 
     if not leads and errors:

--- a/lead-processing-service/main.py
+++ b/lead-processing-service/main.py
@@ -404,11 +404,13 @@ def parse_lead(body: bytes) -> Dict[str, Any] | None:
         return None
 
     lead = {
-        "name":         (record.get("SENDER_NAME")    or "").strip(),
-        "email":        email,
-        "phone_number": (record.get("SENDER_MOBILE")  or "").strip(),
-        "company_name": (record.get("SENDER_COMPANY") or "").strip(),
-        # If your contacts service supports DNC/subscribed or extra fields, add here.
+        "unique_query_id": (record.get("UNIQUE_QUERY_ID") or "").strip(),
+        "name":           (record.get("SENDER_NAME")    or "").strip(),
+        "email":          email,
+        "phone_number":   (record.get("SENDER_MOBILE")  or "").strip(),
+        "company_name":   (record.get("SENDER_COMPANY") or "").strip(),
+        "city":           (record.get("CITY")          or "").strip(),
+        "state":          (record.get("STATE")         or "").strip(),
     }
     return lead
 

--- a/lead-processing-service/send_lead.py
+++ b/lead-processing-service/send_lead.py
@@ -10,7 +10,10 @@ lead = {
     "SENDER_NAME": "John Doe",
     "SENDER_EMAIL": "john.doe@example.com",
     "SENDER_MOBILE": "9876543210",
-    "SENDER_COMPANY": "Acme Corp"
+    "SENDER_COMPANY": "Acme Corp",
+    "UNIQUE_QUERY_ID": "TEST123",
+    "CITY": "Mumbai",
+    "STATE": "MH",
 }
 
 channel.basic_publish(


### PR DESCRIPTION
## Summary
- Persist IndiaMART-specific fields (unique_query_id, city, state, phone, company) in contact service with migrations
- Forward new fields from lead ingestion worker and API
- Display phone, company, city, state and unique ID in campaign manager with search support

## Testing
- `python -m py_compile contact-management-service/main.py lead-processing-service/main.py lead-processing-service/api.py lead-processing-service/send_lead.py`
- `npm test -- --watchAll=false` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689b6a0c48f4832dbb1f6822cb9e50c7