### PR TITLE
Add AI copy generation endpoint and UI with caching

### DIFF
--- a/campaign-management-service/frontend/ui/src/components/AIWriter.jsx
+++ b/campaign-management-service/frontend/ui/src/components/AIWriter.jsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { Card } from './Common';
+
+const cfg = {
+  API_KEY: process.env.REACT_APP_API_KEY || 'your-super-secret-key-12345',
+  email: process.env.REACT_APP_EMAIL_URL || 'http://localhost:8001',
+};
+
+const AIWriter = React.memo(function AIWriter() {
+  const [prompt, setPrompt] = useState('');
+  const [contact, setContact] = useState('{}');
+  const [suggestion, setSuggestion] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const generate = async () => {
+    setLoading(true);
+    try {
+      const { data } = await axios.post(
+        `${cfg.email}/generate-copy`,
+        { prompt, contact: JSON.parse(contact || '{}') },
+        { headers: { 'X-API-Key': cfg.API_KEY } }
+      );
+      setSuggestion(data.text || '');
+    } catch (err) {
+      setSuggestion(err.response?.data?.detail || err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card sx={{ p: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        AI Writer
+      </Typography>
+      <TextField
+        label="Prompt"
+        multiline
+        minRows={2}
+        fullWidth
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        sx={{ mb: 2 }}
+      />
+      <TextField
+        label="Contact JSON"
+        multiline
+        minRows={2}
+        fullWidth
+        value={contact}
+        onChange={(e) => setContact(e.target.value)}
+        sx={{ mb: 2 }}
+      />
+      <Button variant="contained" onClick={generate} disabled={loading}>
+        Generate
+      </Button>
+      {suggestion && (
+        <TextField
+          label="Suggestion"
+          multiline
+          minRows={4}
+          fullWidth
+          value={suggestion}
+          InputProps={{ readOnly: true }}
+          sx={{ mt: 2 }}
+        />
+      )}
+    </Card>
+  );
+});
+
+export default AIWriter;

--- a/campaign-management-service/frontend/ui/src/components/DevPanel.jsx
+++ b/campaign-management-service/frontend/ui/src/components/DevPanel.jsx
@@ -8,6 +8,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import debounce from 'lodash.debounce';
 import { Card, PageContainer } from './Common';
+import AIWriter from './AIWriter';
 import '@xterm/xterm/css/xterm.css';
 
 const cfg = {
@@ -206,6 +207,9 @@ const DevPanel = React.memo(function DevPanel() {
         Live Logs: {logSource || 'None'}
       </Typography>
       <Card elevation={0} ref={terminalRef} sx={{ p: 1.5, mt: 1 }} />
+      <Box sx={{ mt: 4 }}>
+        <AIWriter />
+      </Box>
     </PageContainer>
   );
 });

--- a/email-service/README.md
+++ b/email-service/README.md
@@ -1,0 +1,24 @@
+# Email Service
+
+This service sends emails through the Gmail API and now provides AI assisted copy generation.
+
+## Authentication
+
+1. Place your Google OAuth client credentials in `credentials.json`.
+2. Start the service and call `POST /auth/init` once to open the browser flow and store a `token.json`.
+3. Use `GET /auth/status` to check validity and `POST /auth/reset` to remove the token if you need to reauthenticate.
+
+## Quota limits
+
+Email sending is rate limited using an in‑memory limiter.
+
+| Variable | Default | Description |
+|---|---|---|
+| `EMAIL_RATE_PER_SECOND` | `1` | Maximum emails attempted per second. |
+| `EMAIL_RATE_PER_MINUTE` | `60` | Maximum emails attempted per minute. |
+
+Tune these environment variables to match your quota.
+
+## AI copy generation
+
+`POST /generate-copy` accepts a `prompt` and `contact` object, forwards them to the LLM configured by `LLM_API_URL`, `LLM_MODEL`, and authenticates with `LLM_API_KEY`. Responses are cached in a SQLite table `email_copy_cache` to avoid repeated API calls.

--- a/email-service/requirements.txt
+++ b/email-service/requirements.txt
@@ -7,3 +7,4 @@ structlog>=24.1
 pydantic-settings>=2.3
 python-dotenv>=1.0
 prometheus-client>=0.20
+httpx>=0.26


### PR DESCRIPTION
## Summary
- add `/generate-copy` endpoint in email service that calls an LLM and caches suggestions
- create `email_copy_cache` SQLite table and document auth & quotas in README
- add `AIWriter` React component and expose it in DevPanel

## Testing
- `pytest`
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ccb639be0832dbc040ee682112921